### PR TITLE
Restore closing brace

### DIFF
--- a/elm.cpp
+++ b/elm.cpp
@@ -169,7 +169,8 @@ String ELM::get_pid_desc(byte id) {
 		return myDesc;
 	#else 
 		return ERROR+" parsing of pid data not available on this microcontroller";
-	#endif}
+	#endif
+}
 
 /*
  * Get the vehicle identification number (vin)


### PR DESCRIPTION
The closing brace for get_pid_desc() was not recognized by the compiler due to being placed at the end of a preprocessor directive. This caused compilation to fail:
```
E:\electronics\arduino\libraries\libELM-master\elm.cpp: In member function 'String ELM::get_pid_desc(byte)':

E:\electronics\arduino\libraries\libELM-master\elm.cpp:178:20: error: qualified-id in declaration before '(' token

 String ELM::get_vin() { // tested (without vehicle), response is NO DATA, works
```

Fixes https://github.com/deshi-basara/libELM/issues/1

CC: @smetronic